### PR TITLE
remove object naming and change to property method

### DIFF
--- a/demoauto/input/register.py
+++ b/demoauto/input/register.py
@@ -1,4 +1,4 @@
-class RegisterPageInput(object):
+class RegisterPageInput:
     """Represent register page input data."""
 
     first_name: str = "Volodymyr"

--- a/demoauto/input/sign_on.py
+++ b/demoauto/input/sign_on.py
@@ -1,4 +1,4 @@
-class SignOnPageInput(object):
+class SignOnPageInput:
     """Represent sign on page input data."""
 
     user_name: str = "vyahello"

--- a/demoauto/locators/home.py
+++ b/demoauto/locators/home.py
@@ -1,4 +1,4 @@
-class HomePage(object):
+class HomePage:
     """Represent home page web element locators."""
 
     logo: str = "//img[@alt='Mercury Tours']"

--- a/demoauto/locators/register.py
+++ b/demoauto/locators/register.py
@@ -1,4 +1,4 @@
-class RegistrationPage(object):
+class RegistrationPage:
     """Represent registration page web element locators."""
 
     regis_txt: str = "//*[contains(text(), 'basic information')]"

--- a/demoauto/locators/sing_on.py
+++ b/demoauto/locators/sing_on.py
@@ -1,4 +1,4 @@
-class SingOnPage(object):
+class SingOnPage:
     """Represent sign on page web element locators."""
 
     user_name: str = "//input[@name='userName']"

--- a/demoauto/pages/home.py
+++ b/demoauto/pages/home.py
@@ -16,6 +16,7 @@ class HomePage(Page):
         self._hp_locators: HP_Locators = HP_Locators()
         self._page: Page = BasePage(browser, HomePageUrl())
 
+    @property
     def driver(self) -> Driver:
         return self._page.driver()
 
@@ -26,26 +27,26 @@ class HomePage(Page):
         self._page.close()
 
     def logo(self) -> Element:
-        return self.driver().find_element(
+        return self.driver.find_element(
             self._by.xpath(), self._hp_locators.logo
         )
 
     def contact(self) -> Element:
-        return self.driver().find_element(
+        return self.driver.find_element(
             self._by.xpath(), self._hp_locators.contact
         )
 
     def sign_on(self) -> Element:
-        return self.driver().find_element(
+        return self.driver.find_element(
             self._by.xpath(), self._hp_locators.sing_on
         )
 
     def support(self) -> Element:
-        return self.driver().find_element(
+        return self.driver.find_element(
             self._by.xpath(), self._hp_locators.support
         )
 
     def register(self) -> Element:
-        return self.driver().find_element(
+        return self.driver.find_element(
             self._by.xpath(), self._hp_locators.register
         )

--- a/demoauto/pages/register.py
+++ b/demoauto/pages/register.py
@@ -20,6 +20,7 @@ class RegisterPage(Page):
         self._rp_locators: RP_Locators = RP_Locators()
         self._page: Page = BasePage(browser, RegisterPageUrl())
 
+    @property
     def driver(self) -> Driver:
         return self._page.driver()
 
@@ -30,12 +31,12 @@ class RegisterPage(Page):
         self._page.close()
 
     def register_text(self) -> Element:
-        return self.driver().find_element(
+        return self.driver.find_element(
             self._by.xpath(), self._rp_locators.regis_txt
         )
 
     def set_first_name(self, input_: RegisterPageInput) -> Element:
-        first_name: Element = self.driver().find_element(
+        first_name: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.first_name
         )
         first_name.clear()
@@ -43,21 +44,21 @@ class RegisterPage(Page):
         return first_name
 
     def set_last_name(self, input_: RegisterPageInput) -> None:
-        last_name: Element = self.driver().find_element(
+        last_name: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.last_name
         )
         last_name.clear()
         last_name.send_keys(input_.last_name)
 
     def set_phone(self, input_: RegisterPageInput) -> None:
-        phone: Element = self.driver().find_element(
+        phone: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.phone
         )
         phone.clear()
         phone.send_keys(input_.phone)
 
     def set_email(self, input_: RegisterPageInput) -> None:
-        email: Element = self.driver().find_element(
+        email: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.email
         )
         email.clear()
@@ -65,41 +66,41 @@ class RegisterPage(Page):
 
     def set_country(self, input_: RegisterPageInput) -> None:
         select = Select(
-            self.driver()
-            .find_element(self._by.xpath(), self._rp_locators.country)
-            .element()
+            self.driver.find_element(
+                self._by.xpath(), self._rp_locators.country
+            ).element()
         )
         select.select_by_visible_text(input_.country)
 
     def set_user_name(self, input_: RegisterPageInput) -> None:
-        user_name: Element = self.driver().find_element(
+        user_name: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.user_name
         )
         user_name.clear()
         user_name.send_keys(input_.user_name)
 
     def set_password(self, input_: RegisterPageInput) -> None:
-        password: Element = self.driver().find_element(
+        password: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.password
         )
         password.clear()
         password.send_keys(input_.password)
 
     def confirm_password(self, input_: RegisterPageInput) -> None:
-        confirm_password: Element = self.driver().find_element(
+        confirm_password: Element = self.driver.find_element(
             self._by.xpath(), self._rp_locators.confirm_password
         )
         confirm_password.clear()
         confirm_password.send_keys(input_.password)
 
     def submit(self) -> None:
-        self.driver().find_element(
+        self.driver.find_element(
             self._by.xpath(), self._rp_locators.submit
         ).click()
 
     def confirm_registration(self) -> Element:
         return WebDriverWaitOf(
-            driver=self.driver(), timeout=30
+            driver=self.driver, timeout=30
         ).until_presence_of_element_located(
             ExpectedCondition(self._by.xpath(), self._rp_locators.thank_you)
         )

--- a/demoauto/pages/sing_on.py
+++ b/demoauto/pages/sing_on.py
@@ -19,6 +19,7 @@ class SignOnPage(Page):
         self._sp_locators: SP_Locators = SP_Locators()
         self._page: Page = BasePage(browser, SignOnPageUrl())
 
+    @property
     def driver(self) -> Driver:
         return self._page.driver()
 
@@ -29,30 +30,30 @@ class SignOnPage(Page):
         self._page.close()
 
     def user_name(self, input_: SignOnPageInput) -> None:
-        field: Element = self.driver().find_element(
+        field: Element = self.driver.find_element(
             self._by.xpath(), self._sp_locators.user_name
         )
         field.clear()
         field.send_keys(input_.user_name)
 
     def password(self, input_: SignOnPageInput) -> None:
-        field: Element = self.driver().find_element(
+        field: Element = self.driver.find_element(
             self._by.xpath(), self._sp_locators.password
         )
         field.clear()
         field.send_keys(input_.password)
 
     def text(self) -> Element:
-        return WebDriverWaitOf(self.driver()).until_presence_of_element_located(
+        return WebDriverWaitOf(self.driver).until_presence_of_element_located(
             ExpectedCondition(self._by.xpath(), self._sp_locators.txt)
         )
 
     def register_link(self) -> Element:
-        return WebDriverWaitOf(self.driver()).until_presence_of_element_located(
+        return WebDriverWaitOf(self.driver).until_presence_of_element_located(
             ExpectedCondition(self._by.xpath(), self._sp_locators.register_link)
         )
 
     def login(self) -> None:
-        self.driver().find_element(
+        self.driver.find_element(
             self._by.xpath(), self._sp_locators.login
         ).click()


### PR DESCRIPTION
Hi, these are just small improvements regarding the removal of the object naming that was inherited in `Class`, since I see that this test only coverage for Python 3 only. And also switch the `driver()` method as a property to make the attribute as read-only and better readability